### PR TITLE
Quixxle stone test addition

### DIFF
--- a/test/server/cards/03-WC/QuixxleStone.spec.js
+++ b/test/server/cards/03-WC/QuixxleStone.spec.js
@@ -59,6 +59,23 @@ describe('Quixxle Stone', function () {
             expect(this.player1.inPlay).toContain(this.malison);
         });
 
+        it('restriction updates dynamically when creature counts change', function () {
+            this.player1.play(this.malison); // p1 has more creatures (1 vs 0)
+
+            this.player1.clickCard(this.shooler);
+            expect(this.player1).toHavePrompt('Shooler');
+            expect(this.player1).not.toHavePromptButton('Play this creature');
+
+            this.player2.moveCard(this.badPenny, 'play area'); // counts become equal (1 vs 1)
+
+            this.player1.clickCard(this.shooler);
+            expect(this.player1).toHavePrompt('Shooler');
+            expect(this.player1).toHavePromptButton('Play this creature');
+            this.player1.clickPrompt('Play this creature');
+
+            expect(this.player1.inPlay).toContain(this.shooler);
+        });
+
         it('non-owner player has more creatures, cannot play a creature', function () {
             this.player2.moveCard(this.badPenny, 'play area');
             this.player1.endTurn();

--- a/test/server/cards/03-WC/QuixxleStone.spec.js
+++ b/test/server/cards/03-WC/QuixxleStone.spec.js
@@ -73,6 +73,7 @@ describe('Quixxle Stone', function () {
             expect(this.player1).toHavePrompt('Shooler');
             expect(this.player1).toHavePromptButton('Play this creature');
             this.player1.clickPrompt('Play this creature');
+            this.player1.clickPrompt('Left');
 
             expect(this.player1.inPlay).toContain(this.shooler);
         });

--- a/test/server/cards/03-WC/QuixxleStone.spec.js
+++ b/test/server/cards/03-WC/QuixxleStone.spec.js
@@ -65,6 +65,7 @@ describe('Quixxle Stone', function () {
             this.player1.clickCard(this.shooler);
             expect(this.player1).toHavePrompt('Shooler');
             expect(this.player1).not.toHavePromptButton('Play this creature');
+            this.player1.clickPrompt('Cancel');
 
             this.player2.moveCard(this.badPenny, 'play area'); // counts become equal (1 vs 1)
 


### PR DESCRIPTION
Add a test case for Quixxle Stone to ensure its creature play restriction dynamically updates when creature counts change mid-turn.

---
<a href="https://cursor.com/background-agent?bcId=bc-16cb50d4-4f65-471f-b21f-2ee473de3b07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16cb50d4-4f65-471f-b21f-2ee473de3b07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

